### PR TITLE
Differentiate between StringDataType and IStringDataType

### DIFF
--- a/src/bin/psi4/python.cc
+++ b/src/bin/psi4/python.cc
@@ -718,6 +718,10 @@ bool py_psi_set_local_option_string(std::string const & module, std::string cons
 
     if (data.type() == "string") {
         Process::environment.options.set_str(module, nonconst_key, value);
+        check_for_basis(value, nonconst_key);
+    } else if (data.type() == "istring") {
+        Process::environment.options.set_str_i(module, nonconst_key, value);
+        check_for_basis(value, nonconst_key);
     } else if (data.type() == "boolean") {
         if (boost::to_upper_copy(value) == "TRUE" || boost::to_upper_copy(value) == "YES" || \
           boost::to_upper_copy(value) == "ON")
@@ -741,7 +745,7 @@ bool py_psi_set_local_option_int(std::string const & module, std::string const &
         Process::environment.options.set_double(module, nonconst_key, val);
     }else if (data.type() == "boolean") {
         Process::environment.options.set_bool(module, nonconst_key, value ? true : false);
-    }else if (data.type() == "string") {
+    }else if (data.type() == "string" || data.type() == "istring") {
         Process::environment.options.set_str(module, nonconst_key, boost::lexical_cast<std::string>(value));
     }else{
         Process::environment.options.set_int(module, nonconst_key, value);
@@ -775,7 +779,7 @@ bool py_psi_set_global_option_string(std::string const & key, std::string const 
     string nonconst_key = boost::to_upper_copy(key);
     Data& data = Process::environment.options[nonconst_key];
 
-    if (data.type() == "string") {
+    if (data.type() == "string" || data.type() == "istring") {
         Process::environment.options.set_global_str(nonconst_key, value);
     } else if (data.type() == "boolean") {
         if (boost::to_upper_copy(value) == "TRUE" || boost::to_upper_copy(value) == "YES" || \
@@ -800,7 +804,7 @@ bool py_psi_set_global_option_int(std::string const & key, int value)
         Process::environment.options.set_global_double(nonconst_key, val);
     }else if (data.type() == "boolean") {
         Process::environment.options.set_global_bool(nonconst_key, value ? true : false);
-    }else if (data.type() == "string") {
+    }else if (data.type() == "string" || data.type() == "istring") {
         Process::environment.options.set_global_str(nonconst_key, boost::lexical_cast<std::string>(value));
     }else{
         Process::environment.options.set_global_int(nonconst_key, value);
@@ -957,7 +961,7 @@ object py_psi_get_local_option(std::string const & module, std::string const & k
     py_psi_prepare_options_for_module(module);
     Data& data = Process::environment.options.get_local(nonconst_key);
 
-    if (data.type() == "string")
+    if (data.type() == "string" || data.type() == "istring")
         return str(data.to_string());
     else if (data.type() == "boolean" || data.type() == "int")
         return object(data.to_integer());
@@ -974,7 +978,7 @@ object py_psi_get_global_option(std::string const & key)
     string nonconst_key = key;
     Data& data = Process::environment.options.get_global(nonconst_key);
 
-    if (data.type() == "string")
+    if (data.type() == "string" || data.type() == "istring")
         return str(data.to_string());
     else if (data.type() == "boolean" || data.type() == "int")
         return object(data.to_integer());
@@ -993,7 +997,7 @@ object py_psi_get_option(std::string const & module, std::string const & key)
     py_psi_prepare_options_for_module(module);
     Data& data = Process::environment.options.use_local(nonconst_key);
 
-    if (data.type() == "string")
+    if (data.type() == "string" || data.type() == "istring")
         return str(data.to_string());
     else if (data.type() == "boolean" || data.type() == "int")
         return object(data.to_integer());

--- a/src/bin/psi4/python.cc
+++ b/src/bin/psi4/python.cc
@@ -718,10 +718,8 @@ bool py_psi_set_local_option_string(std::string const & module, std::string cons
 
     if (data.type() == "string") {
         Process::environment.options.set_str(module, nonconst_key, value);
-        check_for_basis(value, nonconst_key);
     } else if (data.type() == "istring") {
         Process::environment.options.set_str_i(module, nonconst_key, value);
-        check_for_basis(value, nonconst_key);
     } else if (data.type() == "boolean") {
         if (boost::to_upper_copy(value) == "TRUE" || boost::to_upper_copy(value) == "YES" || \
           boost::to_upper_copy(value) == "ON")

--- a/src/lib/liboptions/liboptions.cc
+++ b/src/lib/liboptions/liboptions.cc
@@ -494,7 +494,7 @@ void IStringDataType::add_choices(std::string str)
 
 std::string IStringDataType::type() const
 {
-    return std::string("string");
+    return std::string("istring");
 }
 
 std::string IStringDataType::to_string() const
@@ -1026,6 +1026,12 @@ void Options::set_double(const std::string & module, const std::string &key, dou
 void Options::set_str(const std::string & module, const std::string &key, std::string s)
 {
     locals_[module][key] = new StringDataType(s);
+    locals_[module][key].changed();
+}
+
+void Options::set_str_i(const std::string & module, const std::string &key, std::string s)
+{
+    locals_[module][key] = new IStringDataType(s);
     locals_[module][key].changed();
 }
 

--- a/src/lib/liboptions/liboptions.h
+++ b/src/lib/liboptions/liboptions.h
@@ -400,6 +400,7 @@ public:
     void set_int(const std::string &module, const std::string &key, int i);
     void set_double(const std::string & module, const std::string &key, double d);
     void set_str(const std::string & module, const std::string &key, std::string s);
+    void set_str_i(const std::string & module, const std::string &key, std::string s);
     void set_python(const std::string &module, const std::string& key, const boost::python::object &p);
     void set_array(const std::string &module, const std::string& key);
 


### PR DESCRIPTION
When reading the options from the input file, all strings are set as
StringDataType even if they are IStringDataType.

I only did it for the 'local' options and not the global ones.