### PR TITLE
PsiUtil seems to be missing from the PSILIBS list

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -225,7 +225,8 @@ set(PSILIB mints_wrapper dfmp2 dfocc scf ccenergy ccsort psimrcc transqt2
            cchbar cclambda ccdensity transqt ccresponse detci occ mrcc fnocc
            cceom adc thermo functional disp thce 3index deriv_wrapper optking
            findif mints trans dpd chkpt iwl psio qt ciomr options moinfo psi4util
-           stable deriv scfgrad int diis plugin parallel parallel2 babel frag efp_solver efp)
+           stable deriv scfgrad int diis plugin parallel parallel2 babel frag efp_solver efp
+           PsiUtil)
 
 # PCMSolver
 if(ENABLE_PCMSOLVER)


### PR DESCRIPTION
I cannot get PSI to compile without this. `PsiUtil` gets add to the link list but in the wrong place (after the boost libs), causing it to have undefined references.