### PR TITLE
Do not hardcode path for Perl

### DIFF
--- a/tests/psitest.pl
+++ b/tests/psitest.pl
@@ -1,4 +1,4 @@
-#!/usr/bin/perl 
+#!/usr/bin/env perl 
 
 #
 # Rules of use:


### PR DESCRIPTION
This uses whatever perl it finds in the `$PATH`. If you use a non-default perl, hardcoding the perl path is a pain.