### PR TITLE
Fix inputparser.py bug

### DIFF
--- a/lib/python/inputparser.py
+++ b/lib/python/inputparser.py
@@ -159,7 +159,7 @@ def process_from_file_command(matchobj):
            mol+=i
            mol+="\n"
     return mol
-    
+
 
 def process_pubchem_command(matchobj):
     """Function to process match of ``pubchem`` in molecule block."""
@@ -648,7 +648,7 @@ def process_input(raw_input, print_level=1):
     # Return from handling literal blocks to normal processing
 
     # Nuke all comments
-    comment = re.compile(r'[^\\]#.*')
+    comment = re.compile(r'(^|[^\\])#.*')
     temp = re.sub(comment, '', temp)
     # Now, nuke any escapes from comment lines
     comment = re.compile(r'\\#')


### PR DESCRIPTION
The following input file breaks `inputparser.py`

```
$ cat input.dat
# ccansmi: O=C(C#C)C=O

molecule h2 {
H
H 1 0.9
}

set basis 6-31G**
energy('scf')
```

The exception is
```
$ psi4 input.dat
Input error: Unmatched (
```

The error is specific to the fact that the comment appears on the first line of the file.