### PR TITLE
Inputparser fix for slashes inside option string

### DIFF
--- a/lib/python/inputparser.py
+++ b/lib/python/inputparser.py
@@ -78,7 +78,7 @@ def quotify(string):
     """
     # This wraps anything that looks like a string in quotes, and removes leading
     # dollar signs from python variables
-    wordre = re.compile(r'(([$]?)([-+()*.\w\"\']+))')
+    wordre = re.compile(r'(([$]?)([-+()*.\w\"\'/\\]+))')
     string = wordre.sub(process_word_quotes, string)
     return string
 


### PR DESCRIPTION
The following type of `set` block breaks inputparser in the `quotify` function:
```
set {
    myplugin 'a/c'
    myplugin 'a\b'
}
```

with errors like
```
Traceback (most recent call last):
  File "<string>", line 14, in <module>
TypeError: unsupported operand type(s) for /: 'str' and 'str'
```

and 

```
  File "<string>", line 15
    psi4.set_global_option("MYPLUGIN", "'a"\"b'")
                                                ^
SyntaxError: unexpected character after line continuation character
```