### PR TITLE
Build plugins without psi installed

### DIFF
--- a/plugins/CMakeLists.txt
+++ b/plugins/CMakeLists.txt
@@ -11,7 +11,7 @@ add_custom_target(plugin_${PLUG}
     ALL
     DEPENDS ${PSIEXE}
     COMMAND ${CMAKE_COMMAND} -E remove_directory ${CMAKE_CURRENT_BINARY_DIR}/${PLUG}
-    COMMAND ${PSIEXE} --new-plugin ${PLUG}
+    COMMAND ${PSIEXE} --psidatadir ${CMAKE_SOURCE_DIR}/lib --new-plugin ${PLUG}
     COMMAND ${CMAKE_COMMAND} -E chdir ${CMAKE_CURRENT_BINARY_DIR}/${PLUG} $(MAKE)
     COMMENT "Build ${PLUG} example plugin"
     VERBATIM)

--- a/plugins/aointegrals/CMakeLists.txt
+++ b/plugins/aointegrals/CMakeLists.txt
@@ -12,7 +12,7 @@ endforeach(src)
 add_custom_target(plugin_${PLUG}
     ALL
     DEPENDS ${PSIEXE}
-    COMMAND ${PSIEXE} --new-plugin-makefile
+    COMMAND ${PSIEXE} --psidatadir ${CMAKE_SOURCE_DIR}/lib --new-plugin-makefile
     COMMAND $(MAKE)
     COMMENT "Build ${PLUG} example plugin"
     VERBATIM)

--- a/plugins/backtrans/CMakeLists.txt
+++ b/plugins/backtrans/CMakeLists.txt
@@ -12,7 +12,7 @@ endforeach(src)
 add_custom_target(plugin_${PLUG}
     ALL
     DEPENDS ${PSIEXE}
-    COMMAND ${PSIEXE} --new-plugin-makefile
+    COMMAND ${PSIEXE} --psidatadir ${CMAKE_SOURCE_DIR}/lib --new-plugin-makefile
     COMMAND $(MAKE)
     COMMENT "Build ${PLUG} example plugin"
     VERBATIM)

--- a/plugins/mointegrals/CMakeLists.txt
+++ b/plugins/mointegrals/CMakeLists.txt
@@ -12,7 +12,7 @@ endforeach(src)
 add_custom_target(plugin_${PLUG}
     ALL
     DEPENDS ${PSIEXE}
-    COMMAND ${PSIEXE} --new-plugin-makefile
+    COMMAND ${PSIEXE} --psidatadir ${CMAKE_SOURCE_DIR}/lib --new-plugin-makefile
     COMMAND $(MAKE)
     COMMENT "Build ${PLUG} example plugin"
     VERBATIM)

--- a/plugins/mollerplesset2/CMakeLists.txt
+++ b/plugins/mollerplesset2/CMakeLists.txt
@@ -12,7 +12,7 @@ endforeach(src)
 add_custom_target(plugin_${PLUG}
     ALL
     DEPENDS ${PSIEXE}
-    COMMAND ${PSIEXE} --new-plugin-makefile
+    COMMAND ${PSIEXE} --psidatadir ${CMAKE_SOURCE_DIR}/lib --new-plugin-makefile
     COMMAND $(MAKE)
     COMMENT "Build ${PLUG} example plugin"
     VERBATIM)

--- a/plugins/sointegrals/CMakeLists.txt
+++ b/plugins/sointegrals/CMakeLists.txt
@@ -12,7 +12,7 @@ endforeach(src)
 add_custom_target(plugin_${PLUG}
     ALL
     DEPENDS ${PSIEXE}
-    COMMAND ${PSIEXE} --new-plugin-makefile
+    COMMAND ${PSIEXE} --psidatadir ${CMAKE_SOURCE_DIR}/lib --new-plugin-makefile
     COMMAND $(MAKE)
     COMMENT "Build ${PLUG} example plugin"
     VERBATIM)


### PR DESCRIPTION
The PSIDATADIR is not yet available when building these.

Fix for #90 