### PR TITLE
Use $TMPDIR for default of PSI_SCRATCH when set

### DIFF
--- a/src/bin/psi4/psi_start.cc
+++ b/src/bin/psi4/psi_start.cc
@@ -365,7 +365,8 @@ void print_usage(void)
     printf(" -w  --wipe                Clean out your scratch area.\n");
     printf("\n");
     printf("Environment Variables\n");
-    printf("     PSI_SCRATCH           Directory where scratch files are written. Default: /tmp/\n");
+    printf("     PSI_SCRATCH           Directory where scratch files are written.\n");
+    printf("                           Default: $TMPDIR (or /tmp/ when not set)\n");
     printf("                           This should be a local, not network, disk\n");
 
     exit(EXIT_FAILURE);

--- a/src/lib/libpsio/filemanager.cc
+++ b/src/lib/libpsio/filemanager.cc
@@ -26,18 +26,32 @@
 #include "psio.h"
 #include <unistd.h>
 #include <cstdio>
+#include <cstdlib>
 #include "exception.h"
 #include "psi4-dec.h"
 #include "libparallel/ParallelPrinter.h"
 namespace psi{
 
-PSIOManager::PSIOManager() : default_path_("/tmp/")
+PSIOManager::PSIOManager()
 {
     pid_ = psio_getpid();
+
+    // set the default to /tmp unless one of the
+    // TMP environment variables is set
+    if(std::getenv("TMPDIR"))
+        set_default_path(std::getenv("TMPDIR"));
+    else if(std::getenv("TEMP"))
+        set_default_path(std::getenv("TEMP"));
+    else if(std::getenv("TMP"))
+        set_default_path(std::getenv("TMP"));
+    else
+        set_default_path("/tmp");
 }
+
 PSIOManager::~PSIOManager()
 {
 }
+
 boost::shared_ptr<PSIOManager> PSIOManager::shared_object()
 {
     return _default_psio_manager_;

--- a/src/lib/libpsio/psio.hpp
+++ b/src/lib/libpsio/psio.hpp
@@ -33,7 +33,9 @@ extern boost::shared_ptr<PSIOManager> _default_psio_manager_;
    */
 class PSIOManager {
 private:
-    /// Default path for unspec'd file numbers (defaults to /tmp/)
+    /// Default path for unspec'd file numbers
+    // (defaults to either $TMP, $TEMPDIR, $TMP or /tmp/ in 
+    // that order)
     std::string default_path_;
     /// Specific paths for arbitrary file numbers
     std::map<int, std::string> specific_paths_;


### PR DESCRIPTION
On some systems, the default temp location should not be `/tmp`
but it is set by either `$TMPDIR`, `$TEMP` or `$TMP` (commenly done on HPC
systems, where the temp location may be somthing special, a ssd for example).
This patch first checks those 3 environment variables
and uses its value when set. It falls back to `/tmp` when
nothing is set.

`std::getenv` needs C++11 to be thread safe.