### PR TITLE
Exception Formatting

### DIFF
--- a/src/bin/psi4/python.cc
+++ b/src/bin/psi4/python.cc
@@ -1370,7 +1370,13 @@ void psi4_python_module_finalize()
 
 void translate_psi_exception(const PsiException& e)
 {
+#ifdef DEBUG
+    PyObject* message = PyString_FromFormat("%s (%s:%d)", e.what(), e.file(), e.line());
+    PyErr_SetObject(PyExc_RuntimeError, message);
+    Py_DECREF(message);
+#else
     PyErr_SetString(PyExc_RuntimeError, e.what());
+#endif
 }
 
 // Tell python about the default final argument to the array setting functions


### PR DESCRIPTION
Modifies the exception translator to communicate the file() and line() information to the python exception wrapper class. When debugging a plugin (my use case), this makes it much easier to figure out the source of an exception that's thrown from C++ as `throw PSIEXCEPTION('message')`.