### PR TITLE
Modify gitversion.py to work in python3

### DIFF
--- a/src/bin/psi4/gitversion.py
+++ b/src/bin/psi4/gitversion.py
@@ -30,7 +30,8 @@ def write_version(branch, mmp, ghash, status):
 try:
     command = "git symbolic-ref -q HEAD"
     process = subprocess.Popen(command.split(), stderr=subprocess.PIPE,
-                               stdout=subprocess.PIPE, cwd=top_srcdir)
+                               stdout=subprocess.PIPE, cwd=top_srcdir,
+                               universal_newlines=True)
     (out, err) = process.communicate()
     branch = str(out).rstrip()[11:]
     if process.returncode:
@@ -42,7 +43,8 @@ except:
 try:
     command = "git describe --long --dirty --always"
     process = subprocess.Popen(command.split(), stderr=subprocess.PIPE,
-                               stdout=subprocess.PIPE, cwd=top_srcdir)
+                               stdout=subprocess.PIPE, cwd=top_srcdir,
+                               universal_newlines=True)
     (out, err) = process.communicate()
     fields = str(out).rstrip().split('-')
 


### PR DESCRIPTION
With the current code, when `make update_version` is run with py3, the fields variable is something like `["b'f9256f7\\n'"]`, with the extra escaped newline.