### PR TITLE
Fix python 2.6

### DIFF
--- a/lib/python/inputparser.py
+++ b/lib/python/inputparser.py
@@ -729,7 +729,9 @@ def process_input(raw_input, print_level=1):
     def future_replace(m):
         future_imports.append(m.group(0))
         return ''
-    temp = re.sub('^from __future__ import .*$', future_replace, temp, flags=re.MULTILINE)
+
+    future_string = re.compile('^from __future__ import .*$', flags=re.MULTILINE)
+    temp = re.sub(future_string, future_replace, temp)
 
     # imports
     imports = '\n'.join(future_imports) + '\n'

--- a/lib/python/qcdb/libmintsmolecule.py
+++ b/lib/python/qcdb/libmintsmolecule.py
@@ -28,7 +28,7 @@ import math
 try:
     from collections import OrderedDict
 except ImportError:
-    from oldpymodules import OrderedDict
+    from .oldpymodules import OrderedDict
 from .periodictable import *
 from .physconst import *
 from .vecutil import *


### PR DESCRIPTION
Fix for #169. I didn't run the whole test suite, but I did run `cc1`, `opt3` with python2.6. 