### PR TITLE
Fixed conda linktest printing

### DIFF
--- a/conda-recipe/psi4/post-link.sh
+++ b/conda-recipe/psi4/post-link.sh
@@ -1,4 +1,6 @@
 set +x off
+
+#Print install text
 echo ""
 echo ""
 echo "  Thank you for installing psi4. Additional resources:"
@@ -18,6 +20,7 @@ echo "    export PATH=${PREFIX}/bin:\$PATH"
 echo "    export PSI_SCRATCH=/path/to/existing/writable/local-not-network/disk/for/scratch/files"
 echo ""
 
+#Create input file
 cat > linktest.in << EOL
 memory 250 mb
 
@@ -53,6 +56,11 @@ compare_values(-0.001672292164, psi4.get_variable("SAPT DISP ENERGY"), 6, "SAPT0
 compare_values(-0.002235581423, psi4.get_variable("SAPT SAPT0 ENERGY"), 6, "SAPT0 Etotal")
 EOL
 
-PSIOUT=`PSI_SCRATCH=/tmp ${PREFIX}/bin/psi4 linktest.in`
+#Run test calculation
+PSIOUT=`PSI_SCRATCH=/tmp; ${PREFIX}/bin/psi4 -i linktest.in -o linktest.out > linktest.txt`
 echo $PSIOUT
+#Print test results
+cat linktest.txt
 echo ""
+#Remove temporary files
+rm -f linktest.in linktest.out linktest.txt timer.dat


### PR DESCRIPTION
When PSI4 updates in miniconda, the testing dialogue,
```
Nuclear Repulsion Energy..........................................PASSED
SAPT0 Eelst.......................................................PASSED
SAPT0 Eexch.......................................................PASSED
SAPT0 Eind........................................................PASSED
SAPT0 Edisp.......................................................PASSED
SAPT0 Etotal......................................................PASSED
```
prints as a single line which is wrapped by the terminal:
```
Nuclear Repulsion Energy..........................................PASSED SAPT0 Eelst....
...................................................PASSED SAPT0 Eexch...................
....................................PASSED SAPT0 Eind...................................
.....................PASSED SAPT0 Edisp.................................................
......PASSED SAPT0 Etotal......................................................PASSED
```
It seems like there should be a newline after each "PASSED". I updated the post-link.sh script to print the test dialogue with cat instead of echo. This seems to fix the problem on my machines (Ubuntu and RedHat with Gnome terminal and Konsole).

While I was updating the printing, I also added comments and made the script delete the temporary files after PSI4 is done running.
