### PR TITLE
Replace deprecated defined(%hash) with exists()

### DIFF
--- a/doc/sphinxman/document_options_c.pl
+++ b/doc/sphinxman/document_options_c.pl
@@ -147,7 +147,7 @@ sub print_hash
           @OrderedSubsection = @{$ModuleSubsections{$Module}};
      }
      foreach my $Subsection (@OrderedSubsection) {
-       if (defined(%{$hash{$Module}{$Subsection}})) { 
+       if (exists($hash{$Module}{$Subsection})) {
          if($Subsection){
              if ($print_description) { 
                  my $Secdivider = "_" x (length($Subsection)-1);


### PR DESCRIPTION
Documentation fails to build with perl 5.22 and reports the following error:

Can't use 'defined(%hash)' (Maybe you should just omit the defined()?)
at /build/psi4-0.3/doc/sphinxman/document_options_c.pl line 150.
doc/sphinxman/CMakeFiles/sphinxman.dir/build.make:106: recipe for
target 'doc/sphinxman/source/autodoc_abbr_options_c.rst' failed