### PR TITLE
PCMSolver is no longer a git submodule.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "interfaces/pcmsolver"]
-	path = interfaces/pcmsolver
-	url = https://github.com/PCMSolver/pcmsolver.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -237,18 +237,9 @@ set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR}/bin)
 
 set_property(GLOBAL PROPERTY PSILIB)
 
-# PCMSolver
+# PCMSolver Detection
 if(ENABLE_PCMSOLVER)
-   find_package(ZLIB)
-    if (NOT ZLIB_FOUND)
-        message(FATAL_ERROR "No Zlib, no PCMSolver. Skip with -DENABLE_PCMSOLVER=OFF")
-        # TODO ability to build psi4 against pre-built pcmsolver library like chemps2
-        #message(FATAL_ERROR "No Zlib, no PCMSolver. Build against existing with -DPCMSOLVER_ROOT=/path/to/pcmsolver or skip with -DENABLE_PCMSOLVER=OFF")
-   else()
-      add_definitions(-DHAVE_PCMSOLVER)
-      message(STATUS "Polarizable Continuum Model via PCMSolver ENABLED")
-      link_directories(${PROJECT_BINARY_DIR}/interfaces/lib)
-   endif()
+  include(ConfigPCMSolver)
 endif()
 
 #If we have MPI we may want to also build JKFactory which makes J and K's

--- a/cmake/ConfigPCMSolver.cmake
+++ b/cmake/ConfigPCMSolver.cmake
@@ -1,0 +1,91 @@
+
+# User signal to try pre-built PCMSolver
+if(PCMSOLVER_ROOT)
+  find_package(PCMSolver)
+endif()
+
+# Build PCMSolver as external package if pre-built failed or not signaled
+if(NOT PCMSolver_FOUND)
+  message(STATUS "PCMSolver not found. The pre-packaged version will be built.")
+
+  find_package(ZLIB QUIET)
+  if (NOT ZLIB_FOUND)
+    message(FATAL_ERROR "No Zlib, no PCMSolver. Build against existing with -DPCMSOLVER_ROOT=/path/to/pcmsolver or skip with -DENABLE_PCMSOLVER=OFF")
+  endif()
+
+  set(CUSTOM_PCMSolver_LOCATION ${PROJECT_BINARY_DIR}/interfaces/pcmsolver)
+  include(ExternalProject)
+  get_filename_component(ZLIB_ROOT ${ZLIB_LIBRARIES} PATH)
+  # PCMSolver does not know profile
+  if(CMAKE_BUILD_TYPE MATCHES "profile")
+    set(PCM_BUILD_TYPE "release")
+  else()
+    set(PCM_BUILD_TYPE ${CMAKE_BUILD_TYPE})
+  endif()
+  list(APPEND PCMSolverCMakeArgs
+    -DCMAKE_BUILD_TYPE=${PCM_BUILD_TYPE}
+    -DCMAKE_INSTALL_PREFIX=${PROJECT_BINARY_DIR}/interfaces
+    -DSUBMODULES_INSTALL_PREFIX=${PROJECT_BINARY_DIR}/interfaces
+    -DCMAKE_Fortran_COMPILER=${CMAKE_Fortran_COMPILER}
+    -DEXTRA_Fortran_FLAGS=${PCM_EXTRA_Fortran_FLAGS}
+    -DCMAKE_C_COMPILER=${CMAKE_C_COMPILER}
+    -DEXTRA_C_FLAGS=${PCM_EXTRA_C_FLAGS}
+    -DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER}
+    -DEXTRA_CXX_FLAGS=${PCM_EXTRA_CXX_FLAGS}
+    -DENABLE_CXX11_SUPPORT=${ENABLE_CXX11_SUPPORT}
+    -DBOOST_INCLUDEDIR=${BOOST_INCLUDE_DIRS}
+    -DBOOST_LIBRARYDIR=${BOOST_LIBRARIES}
+    -DENABLE_64BIT_INTEGERS=${ENABLE_64BIT_INTEGERS}
+    -DENABLE_TESTS=OFF
+    -DENABLE_LOGGER=OFF
+    -DENABLE_TIMER=OFF
+    -DBUILD_STANDALONE=OFF
+    -DENABLE_FORTRAN_API=OFF
+    -DSTATIC_LIBRARY_ONLY=ON
+    -DENABLE_GENERIC=${ENABLE_STATIC_LINKING}
+    -DZLIB_ROOT=${ZLIB_ROOT}
+    -DPYTHON_INTERPRETER=${PYTHON_EXECUTABLE}
+    -DCMAKE_INSTALL_PREFIX:PATH=<INSTALL_DIR>
+    -DCMAKE_INSTALL_LIBDIR=lib
+    )
+  ExternalProject_Add(interface_pcmsolver
+    PREFIX ${CUSTOM_PCMSolver_LOCATION}
+    GIT_REPOSITORY https://github.com/PCMSolver/pcmsolver
+    GIT_TAG master
+    CMAKE_ARGS "${PCMSolverCMakeArgs}"
+    INSTALL_DIR "${CUSTOM_PCMSolver_LOCATION}/install"
+    )
+
+  # Set also variables usually set by find_package
+  ExternalProject_Get_Property(interface_pcmsolver INSTALL_DIR)
+  set(PCMSolver_LIBRARY "${INSTALL_DIR}/lib/libpcm.a")
+  file(MAKE_DIRECTORY ${INSTALL_DIR}/include/pcmsolver)  # note [1] below
+  set(PCMSolver_INCLUDE_DIRS "${INSTALL_DIR}/include" ${ZLIB_INCLUDE_DIRS})
+  set(PCMSolver_LIBRARIES ${PCMSolver_LIBRARY} ${ZLIB_LIBRARIES})
+
+  # Set target for psipcm and psi4 to depend upon as set by find_package
+  add_library(PCMSolver::PCMSolver STATIC IMPORTED GLOBAL)
+  add_dependencies(PCMSolver::PCMSolver interface_pcmsolver)
+  set_target_properties(PCMSolver::PCMSolver PROPERTIES
+    IMPORTED_LOCATION "${PCMSolver_LIBRARY}"
+    INTERFACE_LINK_LIBRARIES "${PCMSolver_LIBRARIES}"
+    INTERFACE_INCLUDE_DIRECTORIES "${PCMSolver_INCLUDE_DIRS}"
+    )
+
+  include_directories(SYSTEM "${PCMSolver_INCLUDE_DIRS}")
+  set(PCMSolver_PARSE_DIR ${INSTALL_DIR}/bin)
+  configure_file(${CMAKE_SOURCE_DIR}/lib/python/pcm_placeholder.py.in
+    ${CMAKE_SOURCE_DIR}/lib/python/pcm_placeholder.py)
+endif()
+
+add_definitions(-DHAVE_PCMSOLVER=1)
+
+# [1] It's nice to have a full PCMSolver::PCMSolver target that has embedded
+# the library, the linking library paths with dependencies, and the include
+# paths with dependencies, just like FindPCMSolver supplies, especially
+# since src/bin/libpsipcm needs the headers for compilation and src/bin/psi4
+# needs all the linking libraries. Problem is that conventional target
+# derived from ExternalProject_Add is a highly sought but not quite
+# certified cmake pattern. Hence INTERFACE_INCLUDE_DIRECTORIES complains
+# that the directories don't exist at configure time. Hence the hack to
+# create an empty directory.

--- a/cmake/FindPCMSolver.cmake
+++ b/cmake/FindPCMSolver.cmake
@@ -1,0 +1,100 @@
+#.rst:
+# FindPCMSolver
+# --------
+#
+# Find the native PCMSolver includes and library and dependencies.
+# Modeled on FindCHEMPS2.cmake
+#
+# IMPORTED Targets
+# ^^^^^^^^^^^^^^^^
+#
+# This module defines :prop_tgt:`IMPORTED` target ``PCMSolver::PCMSolver``, if
+# PCMSolver has been found.
+#
+# Result Variables
+# ^^^^^^^^^^^^^^^^
+#
+# This module defines the following variables:
+#
+# ::
+#
+#   PCMSolver_INCLUDE_DIRS   - where to find pcmsolver/pcmsolver.h, etc.
+#   PCMSolver_LIBRARIES      - List of libraries when using PCMSolver.
+#   PCMSolver_FOUND          - True if PCMSolver found.
+#
+# Hints
+# ^^^^^
+#
+# A user may set ``PCMSOLVER_ROOT`` to a PCMSolver installation root to tell
+# this module where to look.
+
+# defines CMAKE_INSTALL_LIBDIR for Debian package
+include (GNUInstallDirs)
+
+find_package(ZLIB QUIET)
+
+set(_PCMSolver_SEARCHES)
+
+# Search PCMSOLVER_ROOT first if it is set.
+if(PCMSOLVER_ROOT)
+  set(_PCMSolver_SEARCH_ROOT PATHS ${PCMSOLVER_ROOT} NO_DEFAULT_PATH)
+  list(APPEND _PCMSolver_SEARCHES _PCMSolver_SEARCH_ROOT)
+endif()
+
+# Normal search.
+set(_PCMSolver_SEARCH_NORMAL
+  PATHS "[HKEY_LOCAL_MACHINE\\SOFTWARE\\GnuWin32\\PCMSolver;InstallPath]"
+        "$ENV{PROGRAMFILES}/pcmsolver"
+        "/usr"
+  )
+list(APPEND _PCMSolver_SEARCHES _PCMSolver_SEARCH_NORMAL)
+
+set(PCMSolver_NAMES pcm)
+#set(_hold_suffix ${CMAKE_FIND_LIBRARY_SUFFIXES})
+#set(CMAKE_FIND_LIBRARY_SUFFIXES ".a")
+
+# Try each search configuration.
+foreach(search ${_PCMSolver_SEARCHES})
+    find_path(PCMSolver_INCLUDE_DIR
+        NAMES pcmsolver.h
+        ${${search}}
+        PATH_SUFFIXES include)
+      find_path(PCMSolver_PARSE_DIR
+        NAMES pcmsolver.py
+        ${${search}}
+        PATH_SUFFIXES bin)
+    find_library(PCMSolver_LIBRARY
+        NAMES ${PCMSolver_NAMES}
+        ${${search}}
+        PATH_SUFFIXES lib lib64 ${CMAKE_INSTALL_LIBDIR})
+endforeach()
+
+mark_as_advanced(PCMSolver_LIBRARY PCMSolver_INCLUDE_DIR PCMSolver_PARSE_DIR)
+#set(CMAKE_FIND_LIBRARY_SUFFIXES ${_hold_suffix})
+if(DETECT_EXTERNAL_STATIC)
+  set(CMAKE_FIND_LIBRARY_SUFFIXES ".a")
+endif()
+
+# handle the QUIETLY and REQUIRED arguments and set PCMSolver_FOUND to TRUE if
+# all listed variables are TRUE
+include(FindPackageHandleStandardArgs)
+FIND_PACKAGE_HANDLE_STANDARD_ARGS(PCMSolver
+    FOUND_VAR PCMSolver_FOUND
+    REQUIRED_VARS PCMSolver_LIBRARY PCMSolver_INCLUDE_DIR PCMSolver_PARSE_DIR
+                  ZLIB_LIBRARIES ZLIB_INCLUDE_DIRS)
+
+if(PCMSolver_FOUND)
+  set(PCMSolver_INCLUDE_DIRS ${PCMSolver_INCLUDE_DIR} ${ZLIB_INCLUDE_DIRS})
+  set(PCMSolver_LIBRARIES ${PCMSolver_LIBRARY} ${ZLIB_LIBRARIES})
+
+  if(NOT TARGET PCMSolver::PCMSolver)
+    add_library(PCMSolver::PCMSolver UNKNOWN IMPORTED)
+    set_target_properties(PCMSolver::PCMSolver PROPERTIES
+      IMPORTED_LOCATION ${PCMSolver_LIBRARY}
+      INTERFACE_LINK_LIBRARIES "${PCMSolver_LIBRARIES}"
+      INTERFACE_INCLUDE_DIRECTORIES "${PCMSolver_INCLUDE_DIRS}")
+  endif()
+  include_directories(SYSTEM "${PCMSolver_INCLUDE_DIRS}")
+  configure_file(${CMAKE_SOURCE_DIR}/lib/python/pcm_placeholder.py.in
+    ${CMAKE_SOURCE_DIR}/lib/python/pcm_placeholder.py)
+endif()

--- a/lib/python/inputparser.py
+++ b/lib/python/inputparser.py
@@ -364,7 +364,7 @@ def process_pcm_command(matchobj):
     fp.write(block)
     fp.close()
     import pcm_placeholder
-    sys.path.append(pcm_placeholder.PCMSOLVER_PARSE_DIR)
+    sys.path.append(pcm_placeholder.PCMSolver_PARSE_DIR)
     import pcmsolver
     pcmsolver.parse_pcm_input('pcmsolver.inp')
     return "" # The file has been written to disk; nothing needed in Psi4 input

--- a/lib/python/pcm_placeholder.py.in
+++ b/lib/python/pcm_placeholder.py.in
@@ -15,4 +15,4 @@ that has to be configured by CMake
 
 """
 
-PCMSOLVER_PARSE_DIR='@PCMSOLVER_PARSE_DIR@'
+PCMSolver_PARSE_DIR='@PCMSolver_PARSE_DIR@'

--- a/setup
+++ b/setup
@@ -297,14 +297,21 @@ def parse_input():
             action='store',
             choices=('on', 'off'),
             default=None,
-            help="""Enable PCMSolver external project (requires Fortran, zlib). If this is left blank, 
+            help="""Enable PCMSolver external project (requires Fortran, zlib). If this is left blank,
             PCMSolver will be included if Fortran compiler specified, otherwise not.""")
+    group.add_argument('--pcmsolver-dir',
+            action='store',
+            default=None,
+            help="""The install directory for a pre-built PCMSolver.
+            'lib/libpcm.so' and 'include/pcmsolver/pcmsolver.h' should be in this directory.
+            If this is left blank cmake will build one for you.""",
+            metavar='PATH')
     # CheMPS2 package
     group.add_argument('--chemps2',
             action='store',
             choices=('on', 'off'),
             default=None,
-            help="""Enable CheMPS2 external project (requires hdf5, gsl, zlib). If this is left blank, 
+            help="""Enable CheMPS2 external project (requires hdf5, gsl, zlib). If this is left blank,
             CheMPS2 will be included.""")
     group.add_argument('--chemps2-dir',
             action='store',
@@ -514,6 +521,8 @@ def gen_cmake_command(args):
     if args.hdf5_dir:
         command += ' -DHDF5_ROOT={0}'.format(args.hdf5_dir)
 
+    if args.pcmsolver_dir:
+        command += ' -DPCMSOLVER_ROOT={0}'.format(args.pcmsolver_dir)
     if args.chemps2_dir:
         command += ' -DCHEMPS2_ROOT={0}'.format(args.chemps2_dir)
 

--- a/src/bin/psi4/CMakeLists.txt
+++ b/src/bin/psi4/CMakeLists.txt
@@ -60,6 +60,9 @@ target_link_libraries(psi4 ${LINKLIBS})
 if(ENABLE_CHEMPS2)
     target_link_libraries(psi4 CHEMPS2::CHEMPS2)
 endif()
+if(ENABLE_PCMSOLVER)
+  target_link_libraries(psi4 PCMSolver::PCMSolver)
+endif()
 
 # standalone python module psi4.so
 add_executable(psi4so EXCLUDE_FROM_ALL ${sources_list})

--- a/src/lib/libpsipcm/CMakeLists.txt
+++ b/src/lib/libpsipcm/CMakeLists.txt
@@ -1,46 +1,4 @@
 # <<<  PCMSolver Roberto Di Remigio  >>>
-# PCMSolver uses the git submodules + CMake ExternalProject_Add combo
-if(ENABLE_PCMSOLVER)
-    include(ConfigExternal)
-    get_filename_component(ZLIB_ROOT ${ZLIB_LIBRARIES} PATH)
-    # PCMSolver does not know profile
-    if(CMAKE_BUILD_TYPE MATCHES "profile")
-        set(PCM_BUILD_TYPE "release")
-    else()
-        set(PCM_BUILD_TYPE ${CMAKE_BUILD_TYPE})
-    endif()
-    list(APPEND PCMSolverCMakeArgs
-      -DCMAKE_BUILD_TYPE=${PCM_BUILD_TYPE}
-      -DCMAKE_INSTALL_PREFIX=${PROJECT_BINARY_DIR}/interfaces
-      -DSUBMODULES_INSTALL_PREFIX=${PROJECT_BINARY_DIR}/interfaces
-      -DCMAKE_Fortran_COMPILER=${CMAKE_Fortran_COMPILER}
-      -DEXTRA_Fortran_FLAGS=${PCM_EXTRA_Fortran_FLAGS}
-      -DCMAKE_C_COMPILER=${CMAKE_C_COMPILER}
-      -DEXTRA_C_FLAGS=${PCM_EXTRA_C_FLAGS}
-      -DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER}
-      -DEXTRA_CXX_FLAGS=${PCM_EXTRA_CXX_FLAGS}
-      -DENABLE_CXX11_SUPPORT=${ENABLE_CXX11_SUPPORT}
-      -DBOOST_INCLUDEDIR=${BOOST_INCLUDE_DIRS}
-      -DBOOST_LIBRARYDIR=${BOOST_LIBRARIES}
-      -DENABLE_64BIT_INTEGERS=${ENABLE_64BIT_INTEGERS}
-      -DENABLE_TESTS=OFF
-      -DENABLE_LOGGER=OFF
-      -DENABLE_TIMER=OFF
-      -DBUILD_STANDALONE=OFF
-      -DENABLE_FORTRAN_API=OFF
-      -DENABLE_GENERIC=OFF
-      -DZLIB_ROOT=${ZLIB_ROOT}
-      -DPYTHON_INTERPRETER=${PYTHON_EXECUTABLE}
-     )
-
-    add_external(pcmsolver "${PCMSolverCMakeArgs}")
-
-    include_directories(${PROJECT_SOURCE_DIR}/interfaces/pcmsolver/api)
-    set(PCMSOLVER_PARSE_DIR ${PROJECT_BINARY_DIR}/interfaces/bin)
-    configure_file(${CMAKE_SOURCE_DIR}/lib/python/pcm_placeholder.py.in
-	           ${CMAKE_SOURCE_DIR}/lib/python/pcm_placeholder.py)
-endif()
-
 set(headers_list "")
 # List of headers
 list(APPEND headers_list psipcm.h )
@@ -65,15 +23,13 @@ else()
    list(REMOVE_ITEM sources_list "")
 endif()
 
-
 # Build static library
 add_library(psipcm STATIC ${sources_list})
 # Specify dependencies for the library (if any)
-add_dependencies(psipcm pcmsolver)
-list(APPEND PCMSOLVER_LIBS pcm "${CMAKE_Fortran_IMPLICIT_LINK_LIBRARIES}")
-set_property(GLOBAL APPEND PROPERTY LIBLIST psipcm ${PCMSOLVER_LIBS})
+add_dependencies(psipcm mints)
+target_link_libraries(psipcm PCMSolver::PCMSolver)
+set_property(GLOBAL APPEND PROPERTY LIBLIST psipcm)
 if(BUILD_CUSTOM_BOOST)
-   add_dependencies(pcmsolver custom_boost)
    add_dependencies(psipcm custom_boost)
 endif()
 


### PR DESCRIPTION
We use the strategy devised by @loriab for external add ons. This commit provides the necessary Find* and Config* CMake script files. Other modifications take into account the new strategy.