### PR TITLE
bail on backtransformation if dx gets ridiculous

### DIFF
--- a/src/bin/optking/frag_disp.cc
+++ b/src/bin/optking/frag_disp.cc
@@ -303,6 +303,10 @@ bool FRAG::displace_util(double *dq, bool focus_on_constraints) {
       bt_iter_done = true;
       bt_converged = false;
     }
+    else if ( dx_rms > 100.0 ) { // Give up.
+      bt_iter_done = true;
+      bt_converged = false;
+    }
     dx_rms_last = dx_rms;
 
     set_geom_array(new_geom);


### PR DESCRIPTION
Fix for issue #231 .  When I made the linear bend code more robust recently, I tightened up enforcement of nonsense torsions.  In #231, the crash appears to be bad luck mostly, as a dozen iterations into the back-transformation on geometry step 3, we just happen to hit a bogus bend.  Turns out this only happened after the iterative procedure started diverging anyway, so I am adding just a test that gives up faster. 