### PR TITLE
Reduced the number of travis CI cases

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,30 +2,30 @@ language: cpp
 sudo: false
 matrix:
   include:
-  - os: linux
-    compiler: clang
-    addons:
-      apt:
-        sources:
-        - llvm-toolchain-precise
-        - ubuntu-toolchain-r-test
-        - boost-latest
-        - george-edison55-precise-backports
-        packages:
-        - cmake
-        - cmake-data
-        - liblapack-dev
-        - clang-3.8
-        - libboost-filesystem1.55-dev
-        - libboost-chrono1.55-dev
-        - libboost-system1.55-dev
-        - libboost-timer1.55-dev
-        - libboost-python1.55-dev
-        - libboost-regex1.55-dev
-        - libboost-serialization1.55-dev
-        - libboost-thread1.55-dev
-        - gfortran
-    env: CXX_COMPILER='clang++-3.8' C_COMPILER='clang-3.8' Fortran_COMPILER='gfortran' BUILD_TYPE='debug'
+#  - os: linux
+#    compiler: clang
+#    addons:
+#      apt:
+#        sources:
+#        - llvm-toolchain-precise
+#        - ubuntu-toolchain-r-test
+#        - boost-latest
+#        - george-edison55-precise-backports
+#        packages:
+#        - cmake
+#        - cmake-data
+#        - liblapack-dev
+#        - clang-3.8
+#        - libboost-filesystem1.55-dev
+#        - libboost-chrono1.55-dev
+#        - libboost-system1.55-dev
+#        - libboost-timer1.55-dev
+#        - libboost-python1.55-dev
+#        - libboost-regex1.55-dev
+#        - libboost-serialization1.55-dev
+#        - libboost-thread1.55-dev
+#        - gfortran
+#    env: CXX_COMPILER='clang++-3.8' C_COMPILER='clang-3.8' Fortran_COMPILER='gfortran' BUILD_TYPE='debug'
 # No release version for 3.8 because of a bug in that version of the compiler
 
   - os: linux
@@ -52,38 +52,39 @@ matrix:
         - libboost-thread1.55-dev
         - gfortran
     env: CXX_COMPILER='clang++-3.5' C_COMPILER='clang-3.5' Fortran_COMPILER='gfortran' BUILD_TYPE='release' BOOSTSTR=' ' BOOSTBUILD=''
-  - os: linux
-    compiler: clang
-    addons: *1
-    env: CXX_COMPILER='clang++-3.5' C_COMPILER='clang-3.5' Fortran_COMPILER='gfortran' BUILD_TYPE='debug' BOOSTSTR=' ' BOOSTBUILD=''
-  - os: linux
-    compiler: clang
-    addons: &2
-      apt:
-        sources:
-        - llvm-toolchain-precise-3.6
-        - ubuntu-toolchain-r-test
-        - boost-latest
-        - george-edison55-precise-backports
-        packages:
-        - cmake
-        - cmake-data
-        - liblapack-dev
-        - clang-3.6
-        - libboost-filesystem1.55-dev
-        - libboost-chrono1.55-dev
-        - libboost-system1.55-dev
-        - libboost-timer1.55-dev
-        - libboost-python1.55-dev
-        - libboost-regex1.55-dev
-        - libboost-serialization1.55-dev
-        - libboost-thread1.55-dev
-        - gfortran
-    env: CXX_COMPILER='clang++-3.6' C_COMPILER='clang-3.6' Fortran_COMPILER='gfortran' BUILD_TYPE='release'
-  - os: linux
-    compiler: clang
-    addons: *2
-    env: CXX_COMPILER='clang++-3.6' C_COMPILER='clang-3.6' Fortran_COMPILER='gfortran' BUILD_TYPE='debug'
+#  - os: linux
+#    compiler: clang
+#    addons: *1
+#    env: CXX_COMPILER='clang++-3.5' C_COMPILER='clang-3.5' Fortran_COMPILER='gfortran' BUILD_TYPE='debug' BOOSTSTR=' ' BOOSTBUILD=''
+
+#  - os: linux
+#    compiler: clang
+#    addons: &2
+#      apt:
+#        sources:
+#        - llvm-toolchain-precise-3.6
+#        - ubuntu-toolchain-r-test
+#        - boost-latest
+#        - george-edison55-precise-backports
+#        packages:
+#        - cmake
+#        - cmake-data
+#        - liblapack-dev
+#        - clang-3.6
+#        - libboost-filesystem1.55-dev
+#        - libboost-chrono1.55-dev
+#        - libboost-system1.55-dev
+#        - libboost-timer1.55-dev
+#        - libboost-python1.55-dev
+#        - libboost-regex1.55-dev
+#        - libboost-serialization1.55-dev
+#        - libboost-thread1.55-dev
+#        - gfortran
+#    env: CXX_COMPILER='clang++-3.6' C_COMPILER='clang-3.6' Fortran_COMPILER='gfortran' BUILD_TYPE='release'
+#  - os: linux
+#    compiler: clang
+#    addons: *2
+#    env: CXX_COMPILER='clang++-3.6' C_COMPILER='clang-3.6' Fortran_COMPILER='gfortran' BUILD_TYPE='debug'
   - os: linux
     compiler: clang
     addons: &3
@@ -108,31 +109,31 @@ matrix:
         - libboost-thread1.55-dev
         - gfortran
     env: CXX_COMPILER='clang++-3.7' C_COMPILER='clang-3.7' Fortran_COMPILER='gfortran' BUILD_TYPE='release'
-  - os: linux
-    compiler: clang
-    addons: *3
-    env: CXX_COMPILER='clang++-3.7' C_COMPILER='clang-3.7' Fortran_COMPILER='gfortran' BUILD_TYPE='debug'
+#  - os: linux
+#    compiler: clang
+#    addons: *3
+#    env: CXX_COMPILER='clang++-3.7' C_COMPILER='clang-3.7' Fortran_COMPILER='gfortran' BUILD_TYPE='debug'
 
+#  - os: linux
+#    compiler: gcc
+#    addons: &6
+#      apt:
+#        sources:
+#        - ubuntu-toolchain-r-test
+#        - george-edison55-precise-backports
+#        packages:
+#        - cmake
+#        - cmake-data
+#        - liblapack-dev
+#        - g++-4.7
+#        - gcc-4.7
+#        - gfortran-4.7
+#    env: CXX_COMPILER='g++-4.7' C_COMPILER='gcc-4.7' Fortran_COMPILER='gfortran-4.7' BUILD_TYPE='release' BOOSTSTR="--boost-incdir=${TRAVIS_BUILD_DIR}/boost_build/boost_1_57_0 --boost-libdir=${TRAVIS_BUILD_DIR}/boost_build/boost_1_57_0/stage/lib" BOOSTBUILD=".scripts/build_boost.sh 4.7" OMP_NUM_THREADS=2
+#  - os: linux
+#    compiler: gcc
+#    addons: *6
+#    env: CXX_COMPILER='g++-4.7' C_COMPILER='gcc-4.7' Fortran_COMPILER='gfortran-4.7' BUILD_TYPE='debug' BOOSTSTR="--boost-incdir=${TRAVIS_BUILD_DIR}/boost_build/boost_1_57_0 --boost-libdir=${TRAVIS_BUILD_DIR}/boost_build/boost_1_57_0/stage/lib" BOOSTBUILD=".scripts/build_boost.sh 4.7" OMP_NUM_THREADS=2
 
-  - os: linux
-    compiler: gcc
-    addons: &6
-      apt:
-        sources:
-        - ubuntu-toolchain-r-test
-        - george-edison55-precise-backports
-        packages:
-        - cmake
-        - cmake-data
-        - liblapack-dev
-        - g++-4.7
-        - gcc-4.7
-        - gfortran-4.7
-    env: CXX_COMPILER='g++-4.7' C_COMPILER='gcc-4.7' Fortran_COMPILER='gfortran-4.7' BUILD_TYPE='release' BOOSTSTR="--boost-incdir=${TRAVIS_BUILD_DIR}/boost_build/boost_1_57_0 --boost-libdir=${TRAVIS_BUILD_DIR}/boost_build/boost_1_57_0/stage/lib" BOOSTBUILD=".scripts/build_boost.sh 4.7" OMP_NUM_THREADS=2
-  - os: linux
-    compiler: gcc
-    addons: *6
-    env: CXX_COMPILER='g++-4.7' C_COMPILER='gcc-4.7' Fortran_COMPILER='gfortran-4.7' BUILD_TYPE='debug' BOOSTSTR="--boost-incdir=${TRAVIS_BUILD_DIR}/boost_build/boost_1_57_0 --boost-libdir=${TRAVIS_BUILD_DIR}/boost_build/boost_1_57_0/stage/lib" BOOSTBUILD=".scripts/build_boost.sh 4.7" OMP_NUM_THREADS=2
   - os: linux
     compiler: gcc
     addons: &7
@@ -148,29 +149,29 @@ matrix:
         - gcc-4.8
         - gfortran-4.8
     env: CXX_COMPILER='g++-4.8' C_COMPILER='gcc-4.8' Fortran_COMPILER='gfortran-4.8' BUILD_TYPE='release' BOOSTSTR="--boost-incdir=${TRAVIS_BUILD_DIR}/boost_build/boost_1_57_0 --boost-libdir=${TRAVIS_BUILD_DIR}/boost_build/boost_1_57_0/stage/lib" BOOSTBUILD=".scripts/build_boost.sh 4.8" OMP_NUM_THREADS=2
-  - os: linux
-    compiler: gcc
-    addons: *7
-    env: CXX_COMPILER='g++-4.8' C_COMPILER='gcc-4.8' Fortran_COMPILER='gfortran-4.8' BUILD_TYPE='debug' BOOSTSTR="--boost-incdir=${TRAVIS_BUILD_DIR}/boost_build/boost_1_57_0 --boost-libdir=${TRAVIS_BUILD_DIR}/boost_build/boost_1_57_0/stage/lib" BOOSTBUILD=".scripts/build_boost.sh 4.8" OMP_NUM_THREADS=2
-  - os: linux
-    compiler: gcc
-    addons: &8
-      apt:
-        sources:
-        - ubuntu-toolchain-r-test
-        - george-edison55-precise-backports
-        packages:
-        - cmake
-        - cmake-data
-        - liblapack-dev
-        - g++-4.9
-        - gcc-4.9
-        - gfortran-4.9
-    env: CXX_COMPILER='g++-4.9' C_COMPILER='gcc-4.9' Fortran_COMPILER='gfortran-4.9' BUILD_TYPE='release' BOOSTSTR="--boost-incdir=${TRAVIS_BUILD_DIR}/boost_build/boost_1_57_0 --boost-libdir=${TRAVIS_BUILD_DIR}/boost_build/boost_1_57_0/stage/lib" BOOSTBUILD=".scripts/build_boost.sh 4.9" OMP_NUM_THREADS=2
-  - os: linux
-    compiler: gcc
-    addons: *8
-    env: CXX_COMPILER='g++-4.9' C_COMPILER='gcc-4.9' Fortran_COMPILER='gfortran-4.9' BUILD_TYPE='debug' BOOSTSTR="--boost-incdir=${TRAVIS_BUILD_DIR}/boost_build/boost_1_57_0 --boost-libdir=${TRAVIS_BUILD_DIR}/boost_build/boost_1_57_0/stage/lib" BOOSTBUILD=".scripts/build_boost.sh 4.9" OMP_NUM_THREADS=2
+#  - os: linux
+#    compiler: gcc
+#    addons: *7
+#    env: CXX_COMPILER='g++-4.8' C_COMPILER='gcc-4.8' Fortran_COMPILER='gfortran-4.8' BUILD_TYPE='debug' BOOSTSTR="--boost-incdir=${TRAVIS_BUILD_DIR}/boost_build/boost_1_57_0 --boost-libdir=${TRAVIS_BUILD_DIR}/boost_build/boost_1_57_0/stage/lib" BOOSTBUILD=".scripts/build_boost.sh 4.8" OMP_NUM_THREADS=2
+#  - os: linux
+#    compiler: gcc
+#    addons: &8
+#      apt:
+#        sources:
+#        - ubuntu-toolchain-r-test
+#        - george-edison55-precise-backports
+#        packages:
+#        - cmake
+#        - cmake-data
+#        - liblapack-dev
+#        - g++-4.9
+#        - gcc-4.9
+#        - gfortran-4.9
+#    env: CXX_COMPILER='g++-4.9' C_COMPILER='gcc-4.9' Fortran_COMPILER='gfortran-4.9' BUILD_TYPE='release' BOOSTSTR="--boost-incdir=${TRAVIS_BUILD_DIR}/boost_build/boost_1_57_0 --boost-libdir=${TRAVIS_BUILD_DIR}/boost_build/boost_1_57_0/stage/lib" BOOSTBUILD=".scripts/build_boost.sh 4.9" OMP_NUM_THREADS=2
+#  - os: linux
+#    compiler: gcc
+#    addons: *8
+#    env: CXX_COMPILER='g++-4.9' C_COMPILER='gcc-4.9' Fortran_COMPILER='gfortran-4.9' BUILD_TYPE='debug' BOOSTSTR="--boost-incdir=${TRAVIS_BUILD_DIR}/boost_build/boost_1_57_0 --boost-libdir=${TRAVIS_BUILD_DIR}/boost_build/boost_1_57_0/stage/lib" BOOSTBUILD=".scripts/build_boost.sh 4.9" OMP_NUM_THREADS=2
   - os: linux
     compiler: gcc
     addons: &9


### PR DESCRIPTION
Travis CI currently takes 2-6 (average 3) hours to complete depending on the current travis load, which is a bit on the long side. To help with this I am proposing that we reduce the number of build types from 15 to the following:

- Latest clang/gcc with both debug and release flags (4 cases)
- Oldest supported clang/gcc with both debug and release flags (4 cases)

It should be noted that travis CI typically runs the first 3-6 test cases immediately upon submission and then runs the rest in a general queue. The real time killer is when the 15th CI case does not start to run for 2-5 hours after initial submission. With the proposed changes we will hopefully be running through travis consistently in about an hour. 

This will deteriorate our CI coverage a bit; however, I think this keeps with the CI spirit and should catch the corner cases that we really worry about. I am looking a bit into something like Docker in addition to Travis so that we can run a full test suite on a local box at the touch of a button.

PS: Fiddling around with commits to practice squashing.